### PR TITLE
Remove apparently uneeded autoload singletons

### DIFF
--- a/addons/immediate_gizmos/scripts/immediate_gizmos_2d.gd
+++ b/addons/immediate_gizmos/scripts/immediate_gizmos_2d.gd
@@ -1,5 +1,6 @@
 @tool
 extends Node
+class_name ImmediateGizmos2D
 
 ##########################################################################
 

--- a/addons/immediate_gizmos/scripts/immediate_gizmos_3d.gd
+++ b/addons/immediate_gizmos/scripts/immediate_gizmos_3d.gd
@@ -1,5 +1,6 @@
 @tool
 extends Node
+class_name ImmediateGizmos3D
 
 ##########################################################################
 

--- a/addons/immediate_gizmos/scripts/immediate_gizmos_plugin.gd
+++ b/addons/immediate_gizmos/scripts/immediate_gizmos_plugin.gd
@@ -5,11 +5,8 @@ extends EditorPlugin
 
 func _enable_plugin() -> void:
 	assert(ProjectSettings.get_setting("application/run/main_loop_type") == "SceneTree", "To use ImmediateGizmos, the project main loop must be of type 'SceneTree'");
-	add_autoload_singleton("ImmediateGizmos2D", "res://addons/immediate_gizmos/scripts/immediate_gizmos_2d.gd");
-	add_autoload_singleton("ImmediateGizmos3D", "res://addons/immediate_gizmos/scripts/immediate_gizmos_3d.gd");
 
 func _disable_plugin() -> void:
-	remove_autoload_singleton("ImmediateGizmos2D");
-	remove_autoload_singleton("ImmediateGizmos3D");
+	pass
 
 ##########################################################################


### PR DESCRIPTION
Hi there!
I've started using this addons a few weeks ago and its really useful. I was surprised that this is not a basic element of the engine, so thank you very much!
I've noticed that using it created some static_called_on_instance warnings in my code, and I found that there is apparently no need to register/unregister the main classes as autoload singletons since they are completely static.
I've made the quick changes in this branch, so you can add them if you want. Except if I've missed something obvious of course, I just started using Godot this year!😅

pros:
 - no more static_called_on_instance warning
 - instant availability upon adding the addon to a project : 
    - no need to activate the plugin in the project settings
    - not creating any error with the example codes not finding the not-yet-instanciated singletons
 - giving the classes the names of the now-removed singletons makes the change retrocompatible with any previously written code

potential cons:
 - the "enabled" column on the "installed plugins" tab of the project settings has no real impact anymore (would it be possible to display it as "always active" somehow ?)
 - the assertion that the project is is using a SceneTree as its main loop is bypassable by not activating the plugin (perhaps this assert should be done directly where this requirement is needed in the plugin rather than in the _enable_plugin function)